### PR TITLE
Use cadr instead of second

### DIFF
--- a/org-make-toc.el
+++ b/org-make-toc.el
@@ -169,7 +169,7 @@ of from the beginning of the buffer."
            when (eql 'headline (car element))
            do (setq children (caddr element))
            if (funcall pred element)
-           do (setq properties (second element))
+           do (setq properties (cadr element))
            else do (setq properties nil)
            collect (list 'headline
                          properties
@@ -200,7 +200,7 @@ When KEEP-ALL is non-nil, return all entries."
 
            for element in tree
            for type = (car element)
-           for properties = (second element)
+           for properties = (cadr element)
            for children = (cddr element)
            when (eql 'headline type)
            for result = (if keep-all


### PR DESCRIPTION
`second` is an alias to `cadr` that comes from `cl.el` (I think) - and this package doesn't otherwise require cl.el.