### PR TITLE
Fix wrong order of org-make-toc-filename-prefix

### DIFF
--- a/org-make-toc.el
+++ b/org-make-toc.el
@@ -304,7 +304,7 @@ When KEEP-ALL is non-nil, return all entries."
                (filename (if org-make-toc-filename-prefix
                              (file-name-nondirectory (buffer-file-name))
                            "")))
-    (org-make-link-string (concat "#" filename target)
+    (org-make-link-string (concat filename "#" target)
                           (org-make-toc--visible-text title))))
 
 (defun org-make-toc--link-entry-org (entry)


### PR DESCRIPTION
The filename must be *before* the # part.