### PR TITLE
Fix: Add autoload to org-make-toc-mode

### DIFF
--- a/org-make-toc.el
+++ b/org-make-toc.el
@@ -387,6 +387,7 @@ created."
 
 ;;;; Mode
 
+;;;###autoload
 (define-minor-mode org-make-toc-mode
   "Add the `org-make-toc' command to the `before-save-hook' in the current Org buffer.
 With prefix argument ARG, turn on if positive, otherwise off."


### PR DESCRIPTION
I added the following header at the beginning of an Org file, but Emacs didn't find the mode:

```
# -*- mode: org; mode: org-make-toc; -*-
```

This PR will fix the issue.