### PR TITLE
Add an option to automatically insert CUSTOM_ID property to entries

### DIFF
--- a/README.org
+++ b/README.org
@@ -112,15 +112,9 @@ Or, you may activate it in all Org buffers like this:
   (add-hook 'org-mode-hook #'org-make-toc-mode)
 #+END_SRC
 
-** Known Issues
+** Making links work in both Emacs/Org and on GitHub
 
-Unfortunately, due to the way GitHub renders Org documents and links, it's not possible to make links which work in both Org itself and the GitHub-rendered HTML.  See [[https://github.com/wallyqs/org-ruby/issues/11][org-ruby issue #11]].  =toc-org= provides a workaround using =org-link-translation-function= to change how Org handles =#heading=-style links, but, of course, that breaks compatibility with such links that aren't intended to be rendered by GitHub, so it must be manually enabled in each document as appropriate.
-
-As an alternative this approach, this package can optionally insert a =CUSTOM_ID= property for each entry when running =org-make-toc= so that links will work in Org as well:
-
-#+BEGIN_SRC elisp
-  (setq org-make-toc-insert-custom-ids t)
-#+END_SRC
+Because of the way GitHub renders Org documents and links, it's not possible to make links which work in both Org itself and the GitHub-rendered HTML unless headings have ~CUSTOM_ID~ properties.  If the option ~org-make-toc-insert-custom-ids~ is enabled, this package will automatically add them as needed.
 
 * Changelog
 :PROPERTIES:
@@ -128,6 +122,10 @@ As an alternative this approach, this package can optionally insert a =CUSTOM_ID
 :END:
 
 ** 0.6-pre
+
+*Additions*
+
++ Option ~org-make-toc-insert-custom-ids~ automatically adds ~CUSTOM_ID~ properties to headings so links can work on both GitHub-rendered Org files and in Emacs.  (Thanks to [[https://github.com/noctuid][Fox Kiester]].)
 
 *Fixes*
 

--- a/README.org
+++ b/README.org
@@ -116,6 +116,12 @@ Or, you may activate it in all Org buffers like this:
 
 Unfortunately, due to the way GitHub renders Org documents and links, it's not possible to make links which work in both Org itself and the GitHub-rendered HTML.  See [[https://github.com/wallyqs/org-ruby/issues/11][org-ruby issue #11]].  =toc-org= provides a workaround using =org-link-translation-function= to change how Org handles =#heading=-style links, but, of course, that breaks compatibility with such links that aren't intended to be rendered by GitHub, so it must be manually enabled in each document as appropriate.
 
+As an alternative this approach, this package can optionally insert a =CUSTOM_ID= property for each entry when running =org-make-toc= so that links will work in Org as well:
+
+#+BEGIN_SRC elisp
+  (setq org-make-toc-insert-custom-ids t)
+#+END_SRC
+
 * Changelog
 :PROPERTIES:
 :TOC:      :depth 0

--- a/org-make-toc.el
+++ b/org-make-toc.el
@@ -161,11 +161,12 @@ with the destination of the published file."
                  (function :tag "Custom function")))
 
 (defcustom org-make-toc-insert-custom-ids nil
-  "Whether to insert custom ids when using github-compatible links.
-When non-nil and using the default `org-make-toc-link-type-fn' to generate
-github-compatible links, this will automatically insert a corresponding
-CUSTOM_ID property for each entry.  This will allow links to also work in org
-mode.")
+  "Add \"CUSTOM_ID\" properties to headings when using GitHub-compatible links.
+When non-nil and using the default `org-make-toc-link-type-fn' to
+generate GitHub-compatible links, automatically insert a
+\"CUSTOM_ID\" property for each entry.  This will allow links to
+also work in `org-mode' in Emacs."
+  :type 'boolean)
 
 (defcustom org-make-toc-exclude-tags '("noexport")
   "Entries with any of these tags are excluded from TOCs."
@@ -396,6 +397,8 @@ mode.")
                              (file-name-nondirectory (buffer-file-name))
                            "")))
     (when org-make-toc-insert-custom-ids
+      ;; FIXME: Disambiguate the `target' in case multiple headings in the document have the same
+      ;; name (e.g. in a large document, there could be multiple sub-ToCs, each called "Contents").
       (org-set-property "CUSTOM_ID" target))
     (org-make-link-string (concat filename "#" target)
                           (org-make-toc--visible-text title))))

--- a/org-make-toc.el
+++ b/org-make-toc.el
@@ -160,6 +160,13 @@ with the destination of the published file."
                  (const :tag "Org-compatible" org-make-toc--link-entry-org)
                  (function :tag "Custom function")))
 
+(defcustom org-make-toc-insert-custom-ids nil
+  "Whether to insert custom ids when using github-compatible links.
+When non-nil and using the default `org-make-toc-link-type-fn' to generate
+github-compatible links, this will automatically insert a corresponding
+CUSTOM_ID property for each entry.  This will allow links to also work in org
+mode.")
+
 (defcustom org-make-toc-exclude-tags '("noexport")
   "Entries with any of these tags are excluded from TOCs."
   :type '(repeat string))
@@ -388,6 +395,8 @@ with the destination of the published file."
                (filename (if org-make-toc-filename-prefix
                              (file-name-nondirectory (buffer-file-name))
                            "")))
+    (when org-make-toc-insert-custom-ids
+      (org-set-property "CUSTOM_ID" target))
     (org-make-link-string (concat filename "#" target)
                           (org-make-toc--visible-text title))))
 


### PR DESCRIPTION
This will allow links to work on both Github and in Org.  Fixes #20.

I only looked at the existing code briefly, but it looked like `entry` was only called on non-ignored headings.  If that's incorrect or there is something else wrong with this approach, let me know.