### PR TITLE
Added: org-make-toc-auto-toc feature + supporting changes

### DIFF
--- a/README.org
+++ b/README.org
@@ -112,6 +112,13 @@ Or, you may activate it in all Org buffers like this:
   (add-hook 'org-mode-hook #'org-make-toc-mode)
 #+END_SRC
 
+Optionally, you may add files to =org-make-toc-auto-file-list= and call =org-make-toc-auto-toc= in your init.el.
+
+#+BEGIN_SRC elisp
+(add-to-list 'org-make-toc-auto-file-list "/path/to/file.org")
+(org-make-toc-auto-toc)
+#+END_SRC
+
 ** Known Issues
 
 Unfortunately, due to the way GitHub renders Org documents and links, it's not possible to make links which work in both Org itself and the GitHub-rendered HTML.  See [[https://github.com/wallyqs/org-ruby/issues/11][org-ruby issue #11]].  =toc-org= provides a workaround using =org-link-translation-function= to change how Org handles =#heading=-style links, but, of course, that breaks compatibility with such links that aren't intended to be rendered by GitHub, so it must be manually enabled in each document as appropriate.

--- a/org-make-toc.el
+++ b/org-make-toc.el
@@ -471,6 +471,7 @@ created."
 (define-minor-mode org-make-toc-mode
   "Add the `org-make-toc' command to the `before-save-hook' in the current Org buffer.
 With prefix argument ARG, turn on if positive, otherwise off."
+  :lighter " MakeToC"
   :init-value nil
   (unless (derived-mode-p 'org-mode)
     (user-error "Not an Org buffer"))

--- a/org-make-toc.el
+++ b/org-make-toc.el
@@ -4,7 +4,7 @@
 
 ;; Author: Adam Porter <adam@alphapapa.net>
 ;; URL: http://github.com/alphapapa/org-make-toc
-;; Version: 0.5
+;; Version: 0.6
 ;; Package-Requires: ((emacs "26.1") (dash "2.12") (s "1.10.0") (org "9.0"))
 ;; Keywords: Org, convenience
 
@@ -163,6 +163,11 @@ with the destination of the published file."
 (defcustom org-make-toc-exclude-tags '("noexport")
   "Entries with any of these tags are excluded from TOCs."
   :type '(repeat string))
+
+(defcustom org-make-toc-auto-file-list (list)
+  "A list of files that should automatically enable `org-make-toc-mode'"
+  :type '(repeat (file :must-match t))
+  :group 'org-make-toc)
 
 ;;;; Commands
 
@@ -464,6 +469,16 @@ created."
                                   until (eobp)
                                   do (forward-until #'visible-p))))
         (erase-buffer)))))
+
+;;;###autoload
+(defun org-make-toc-auto-toc ()
+  "Activate `org-make-toc-mode' for files in `org-make-toc-auto-file-list'."
+  (add-hook 'org-mode-hook
+            (lambda ()
+              (when (member (buffer-file-name)
+                            (mapcar 'expand-file-name
+                                    org-make-toc-auto-file-list))
+                (org-make-toc-mode 1)))))
 
 ;;;; Mode
 


### PR DESCRIPTION
This merge request includes the commits required to add a convenience feature feature that will allow a user to:

1. Add a list of org files to a custom list
2. Call a function in their init.el that will automatically set up an org-mode-hook function. This function will activate org-make-toc-mode if the `buffer-file-name` is in the custom list

I've been using this feature in my init for a while now and have not had any issues, and thought perhaps you might like it.