### PR TITLE
Fix the issue of before-save-hook being added globally

### DIFF
--- a/README.org
+++ b/README.org
@@ -130,6 +130,7 @@ Because of the way GitHub renders Org documents and links, it's not possible to 
 
 + Tolerate whitespace before drawer opening/closing lines.  ([[https://github.com/alphapapa/org-make-toc/pull/15][#15]], [[https://github.com/alphapapa/org-make-toc/issues/17][#17]].  Thanks to [[https://github.com/progfolio][Nicholas Vollmer]].)
 + Link-type function called with position as argument.  (Fixes occasional bugs with heading IDs.)
++ Mode ~org-make-toc-mode~ now adds to the ~before-save-hook~ in the local buffer rather than globally.  ([[https://github.com/alphapapa/org-make-toc/pull/24][#24]].  Thanks to [[https://github.com/akirak][Akira Komamura]].)
 
 ** 0.5
 

--- a/org-make-toc.el
+++ b/org-make-toc.el
@@ -516,8 +516,9 @@ With prefix argument ARG, turn on if positive, otherwise off."
   :init-value nil
   (unless (derived-mode-p 'org-mode)
     (user-error "Not an Org buffer"))
-  (funcall (if org-make-toc-mode #'add-hook #'remove-hook)
-           'before-save-hook #'org-make-toc)
+  (if org-make-toc-mode
+      (add-hook 'before-save-hook #'org-make-toc nil t)
+    (remove-hook 'before-save-hook #'org-make-toc t))
   (message (format "org-make-toc-mode %s."
                    (if org-make-toc-mode
                        "enabled"


### PR DESCRIPTION
When you enable `org-make-toc-mode`, `org-make-toc` is added to `before-save-hook` globally, and the following message is printed every time if you save a buffer, even if the buffer is not in org-mode:

> org-make-toc: No TOC node found.

This PR fixes the issue.